### PR TITLE
Logic inversion errors in Draw.c fixed.S

### DIFF
--- a/Draw.c
+++ b/Draw.c
@@ -5381,7 +5381,7 @@ void hidesafe(int bnbr)
         }
         blithide(LIFO[i], 0);
     }
-    if (found!=INT_MAX)
+    if (found==INT_MAX)
     {
         for (i = zeroLIFOpointer - 1; i >= 0; i--)
         {
@@ -5446,7 +5446,7 @@ void showsafe(int bnbr, int x, int y)
         }
         blithide(LIFO[i], 0);
     }
-    if (found!=INT_MAX)
+    if (found==INT_MAX)
     {
         for (i = zeroLIFOpointer - 1; i >= 0; i--)
         {


### PR DESCRIPTION
As the github copilot correctly mentioned, there was on two places the logic inverted. Now it should be fine.